### PR TITLE
Change dec2bitarray to a faster implementation

### DIFF
--- a/commpy/utilities.py
+++ b/commpy/utilities.py
@@ -46,9 +46,15 @@ def dec2bitarray(in_number, bit_width):
         Array containing the binary representation of all the input decimal(s).
 
     """
-
-    binary_words = vectorized_binary_repr(np.array(in_number, ndmin=1), bit_width)
-    return np.fromiter(it.chain.from_iterable(binary_words), dtype=np.int8)
+    result = np.zeros(size, 'int')
+    i = 1
+    pox = 0
+    while i <= number:
+        if i & number:
+            result[size - pox - 1] = 1
+        i <<= 1
+        pox += 1
+    return result
 
 
 def bitarray2dec(in_bitarray):


### PR DESCRIPTION
The current and previous implementations of dec2bitarray are a huge chunk of time of the simulation.
This implementation is the fastest that I have found, comparing with the previously used ones.
Is based on this SO answer: https://stackoverflow.com/a/30227161

Test case to compare between the one available in the latest public release, the new currently in the code and the one that I'm proposing:
```
import itertools
import timeit
import numpy as np
from commpy.utilities import dec2bitarray

print(",".join(map(lambda x: str(x), list(dec2bitarray(100000, 121)))))


def proposed(number, size):
    result = np.zeros(size, 'int')
    i = 1
    pox = 0
    while i <= number:
        if i & number:
            result[size - pox - 1] = 1
        i <<= 1
        pox += 1
    return result


print(",".join(map(lambda x: str(x), list(dec2ba(100000, 121)))))


def latest(number, size):
    vectorized_binary_repr = np.vectorize(np.binary_repr)
    binary_words = vectorized_binary_repr(np.array(number, ndmin=1), size)
    return np.fromiter(itertools.chain.from_iterable(binary_words), dtype=np.int8)


print(",".join(map(lambda x: str(x), list(new_dec2ba(100000, 121)))))

repetitions = 100000
print("dec2bitarray".ljust(15),
      timeit.timeit(stmt="dec2bitarray(100000000,121)", setup="from commpy.utilities import dec2bitarray",
                    number=repetitions))

print("proposed".ljust(15),
      timeit.timeit(stmt="proposed(100000000,121)", setup="import numpy as np; from __main__ import proposed",
                    number=repetitions))

print("latest".ljust(15),
      timeit.timeit(stmt="latest(100000000,121)", setup="import numpy as np; from __main__ import latest",
                    number=repetitions))
```

